### PR TITLE
Fix code block formatting in "Null values" section

### DIFF
--- a/02-sql-aggregation.md
+++ b/02-sql-aggregation.md
@@ -186,18 +186,18 @@ the NULL values:
 But if we try to be extra clever, and find the average ourselves, 
 we might get tripped up: 
 
-   SELECT SUM(weight), COUNT(*), SUM(weight)/COUNT(*)
-   FROM summer_2000
-   WHERE species_id == 'PE'
+    SELECT SUM(weight), COUNT(*), SUM(weight)/COUNT(*)
+    FROM summer_2000
+    WHERE species_id == 'PE'
 
 Here the COUNT command includes all six records (even those with null 
 values), but the SUM only includes the 4 records with data in the 
 weight field, giving us an incorrect average.  However, 
 my strategy *will* work if I modify the count command slightly: 
 
-   SELECT SUM(weight), COUNT(weight), SUM(weight)/COUNT(weight)
-   FROM summer_2000
-   WHERE species_id == 'PE'
+    SELECT SUM(weight), COUNT(weight), SUM(weight)/COUNT(weight)
+    FROM summer_2000
+    WHERE species_id == 'PE'
 
 When I count the weight field specifically, it ignores the records 
 with data missing in that field.  So 
@@ -207,20 +207,20 @@ COUNT(field) can return different values.
 Another case is when 
 we use a "negative" query - let's count all the non-female animals: 
 
-   SELECT COUNT(*) 
-   FROM summer_2000
-   WHERE sex != 'F'
+    SELECT COUNT(*)
+    FROM summer_2000
+    WHERE sex != 'F'
 
 Now let's count all the non-male animals: 
 
-   SELECT COUNT(*) 
-   FROM summer_2000
-   WHERE sex != 'M'
+    SELECT COUNT(*)
+    FROM summer_2000
+    WHERE sex != 'M'
 
 But if we compare those two numbers with the total: 
 
-   SELECT COUNT(*) 
-   FROM summer_2000
+    SELECT COUNT(*)
+    FROM summer_2000
 
 We'll see that they don't add up to the total!  That's because SQL 
 doesn't automatically include NULL values in a negative conditional 
@@ -230,8 +230,8 @@ returns the 'not NULL, not x' group. Sometimes this may be what we want -
 but sometimes we may want the missing values included as well!  In that 
 case, we'd need to change our query to: 
 
-  SELECT COUNT(*)
-  FROM summer_2000
-  WHERE sex != 'M' OR sex IS NULL
+    SELECT COUNT(*)
+    FROM summer_2000
+    WHERE sex != 'M' OR sex IS NULL
 
 Previous: [SQL Basic Queries](01-sql-basic-queries.html) Next: [Joins and aliases.](03-sql-joins-aliases.html)


### PR DESCRIPTION
Previously, some of the query examples weren't displaying as a code block, because the Markdown text was not indented enough. This commit fixes that (four spaces of indentation will cause the SELECT statements to display as a code block).

Fixes #105.