### PR TITLE
added discussion of inner and left outer joins to 03-sql-joins-aliases.md

### DIFF
--- a/03-sql-joins-aliases.md
+++ b/03-sql-joins-aliases.md
@@ -82,6 +82,43 @@ actual species names.
 > Write a query that returns the genus, the species, and the weight
 > of every individual captured at the site
 
+### Different join types
+
+We can count the number of records returned by our original join query.
+
+    SELECT COUNT(*)
+    FROM surveys
+    JOIN species
+    USING (species_id);
+
+Notice that this number is smaller than the number of records present in the
+survey data.
+
+    SELECT COUNT(*) FROM surveys;
+
+This is because, by default, SQL only returns records where the joining value
+is present in the join columns of both tables (i.e. it takes the _intersection_
+of the two join columns). This joining behaviour is known as an `INNER JOIN`.
+In fact the `JOIN` command is simply shorthand for `INNER JOIN` and the two
+terms can be used interchangably as they will produce the same result.
+
+We can also tell the computer that we wish to keep all the records in the first
+table by using the command `LEFT OUTER JOIN`, or `LEFT JOIN` for short.
+
+> ### Challenge:
+>
+> Re-write the original query to keep all the entries present in the `surveys`
+> table. How many records are returned by this query?
+
+> ### Challenge:
+> Count the number of records in the `surveys` table that have a `NULL` value
+> in the `species_id` column.
+
+In SQL a `NULL` value in one table can never be joined to a NULL value in a
+second table because `NULL` is not equal to anything, even itself. 
+
+### Combining joins with sorting and aggregation
+
 Joins can be combined with sorting, filtering, and aggregation.  So, if we
 wanted average mass of the individuals on each different type of treatment, we
 could do something like


### PR DESCRIPTION
Proposed changes in response to issue #110. 

Builds on the existing `JOIN` query example to make a distinction between `INNER JOIN` and `LEFT OUTER JOIN`.

To minimize the amount of new material I've made no mention of join types that are not relevant to SQLite. I've also made no mention of the difference between primary/foreign keys. 

