### PR TITLE
Clarify flow and narrative of 00-sql-intro

### DIFF
--- a/_episodes/00-sql-introduction.md
+++ b/_episodes/00-sql-introduction.md
@@ -21,7 +21,12 @@ objectives:
 
 _Note: this should have been done by participants before the start of the workshop._
 
-See [Setup](/sql-ecology-lesson/setup/) for install instructions.
+We use [SQLite Manager](https://addons.mozilla.org/en-us/firefox/addon/sqlite-manager/)
+and the 
+[Portal Project dataset](https://figshare.com/articles/Portal_Project_Teaching_Database/1314459)
+throughout this lesson. See [Setup](/sql-ecology-lesson/setup/) for
+instructions on how to download the data, and also how to install and open
+SQLite Manager.
 
 # Motivation
 
@@ -126,7 +131,9 @@ details of exactly how to import and export data and the
 ## Relational databases
 
 Let's look at a pre-existing database, the `portal_mammals.sqlite`
-file.  Clicking on the "open file" icon and then that file will open the database.  
+file from the Portal Project dataset that we downloaded during
+[Setup](/sql-ecology-lesson/setup/). Clicking on the "open file" icon, then
+find that file and clicking on it will open the database.
 
 You can see the tables in the database by looking at the left hand side of the
 screen under Tables, where each table corresponds to one of the `csv` files 

--- a/setup.md
+++ b/setup.md
@@ -6,7 +6,7 @@ permalink: /setup/
 
 > ## Data
 {: .prereq}
-**Download** this data to your computer: [http://dx.doi.org/10.6084/m9.figshare.1314459](http://dx.doi.org/10.6084/m9.figshare.1314459). Click on **Download all**.
+**Download** this data to your computer: [http://dx.doi.org/10.6084/m9.figshare.1314459](http://dx.doi.org/10.6084/m9.figshare.1314459). Click on **Download all** to download the zip file. Unzip it to a location that you can easily find on your computer.
 
 #### About the data
 The data for this lesson is a part of the Data Carpentry Ecology workshop. 


### PR DESCRIPTION
This modifies the setup and intro slightly to clarify that SQL manager is used
throughout and is more explicit about the location of the first file used
(typical point of confusion).

Related to #133