### PR TITLE
Fix NULLIF example (plot_id data type is TEXT)

### DIFF
--- a/_episodes/03-sql-joins-aliases.md
+++ b/_episodes/03-sql-joins-aliases.md
@@ -209,7 +209,7 @@ is returned. This is useful for "nulling out" specific values.
 
 We can "null out" plot 7:
 
-    SELECT species_id, plot_id, NULLIF(plot_id, 7) AS partial_plot_id
+    SELECT species_id, plot_id, NULLIF(plot_id, "7") AS partial_plot_id
     FROM surveys;
 
 Some more functions which are common to SQL databases are listed in the table


### PR DESCRIPTION
In writing up key points https://github.com/datacarpentry/sql-ecology-lesson/pull/165
for lesson 03, I noticed that the NULLIF example won't work if folks have imported data
using the [type (TEXT) listed in lesson 00](https://github.com/ashander/sql-ecology-lesson/blame/bc6820cb1c2563628a72babb6fa0a08c41a94c73/_episodes/00-sql-introduction.md#L193)

BUT, the pre-existing database, the `portal_mammals.sqlite` has integer types
for `plot_id`, so it'll work with that. Options

1. fix commands to work with current types in imported tables
2. fix types to match pre-existing db