### PR TITLE
add filter to view query

### DIFF
--- a/_episodes/02-sql-aggregation.md
+++ b/_episodes/02-sql-aggregation.md
@@ -150,7 +150,8 @@ results in the *Views* tab just like a table.
 Now, we will be able to access these results with a much shorter notation:
 
     SELECT *
-    FROM summer_2000;
+    FROM summer_2000
+    WHERE species_id == 'PE';
 
 There should only be six records.  If you look at the `weight` column, it's
 easy to see what the average weight would be.  If we use SQL to find the


### PR DESCRIPTION
Fixed the first query from the saved view in the 02-sql-aggregation lesson. In the text, it states "There should only be six records", which is only true with a filter on species_id (as is true for the subsequent queries that build on this one). 

