### PR TITLE
IFNULL on wrong table

### DIFF
--- a/_episodes/03-sql-joins-aliases.md
+++ b/_episodes/03-sql-joins-aliases.md
@@ -191,13 +191,13 @@ The lone "sex" column is only included in the query above to illustrate where
 
 `IFNULL` can be particularly useful in `JOIN`. When joining the `species` and
 `surveys` tables earlier, some results were excluded because the `species_id`
-was `NULL`. We can use `IFNULL` to include them again, re-writing the `NULL` to
+was `NULL` in the surveys table. We can use `IFNULL` to include them again, re-writing the `NULL` to
 a valid joining value:
 
     SELECT surveys.year, surveys.month, surveys.day, species.genus, species.species
     FROM surveys
     JOIN species
-    ON surveys.species_id = IFNULL(species.species_id, 'AB');
+    ON IFNULL(surveys.species_id,'AB') = species.species_id;
 
 > ## Challenge:
 >


### PR DESCRIPTION
In lesson 03-sql-joins-aliases, the example using IFNULL for species_id adds the IFNULL function to the wrong table. The species table does not contain any NULL species_id values, but the surveys table does. 