### PR TITLE
remove permalinks

### DIFF
--- a/_episodes/00-sql-introduction.md
+++ b/_episodes/00-sql-introduction.md
@@ -23,7 +23,7 @@ _Note: this should have been done by participants before the start of the worksh
 
 We use [DB Browser for SQLite](http://sqlitebrowser.org/) and the 
 [Portal Project dataset](https://figshare.com/articles/Portal_Project_Teaching_Database/1314459)
-throughout this lesson. See [Setup](/sql-ecology-lesson/setup/) for
+throughout this lesson. See [Setup](../setup.html) for
 instructions on how to download the data, and also how to install DB Browser for SQLite.
 
 # Motivation

--- a/index.md
+++ b/index.md
@@ -21,7 +21,7 @@ into them and how you can query databases to extract just the information that y
 > their own computers to insure the proper setup of tools for an efficient 
 > workflow. <br>**These lessons assume no prior knowledge of the skills or tools.**
 >
-> To get started, follow the directions in the "[Setup](setup/)" tab to 
+> To get started, follow the directions in the "[Setup](setup.html)" tab to 
 > download data to your computer and follow any installation instructions.
 >
 > #### Prerequisites

--- a/reference.md
+++ b/reference.md
@@ -1,6 +1,5 @@
 ---
 layout: reference
-permalink: /reference/
 ---
 
 ## Glossary

--- a/setup.md
+++ b/setup.md
@@ -1,7 +1,6 @@
 ---
 layout: page
 title: Setup
-permalink: /setup/
 ---
 
 > ## Data


### PR DESCRIPTION
this fixes the issue mentioned in [this comment](https://github.com/datacarpentry/sql-ecology-lesson/issues/229#issuecomment-400636025). Before merging, it would be good to check that links within the lessons pointing to `/setup/` and `/reference/` are updated.

This is a consequence of this change: https://github.com/carpentries/lesson-example/pull/127 