### PR TITLE
Change order of first three queries

### DIFF
--- a/_episodes/01-sql-basic-queries.md
+++ b/_episodes/01-sql-basic-queries.md
@@ -34,7 +34,7 @@ If we want to select a single column, we can type the column name instead of the
     SELECT year
     FROM surveys;
 
-If we want more information, we can just add a new column to the list of fields,
+If we want more information, we can just add more columns to the list of fields,
 right after SELECT:
 
     SELECT year, month, day

--- a/_episodes/01-sql-basic-queries.md
+++ b/_episodes/01-sql-basic-queries.md
@@ -21,15 +21,18 @@ Let's start by using the **surveys** table. Here we have data on every
 individual that was captured at the site, including when they were captured,
 what plot they were captured on, their species ID, sex and weight in grams.
 
-Let’s write an SQL query that selects only the year column from the
-surveys table. SQL queries can be written in the box located under 
-the "Execute SQL" tab. Click on the right arrow above the query box to execute the query. (You can also use the keyboard shortcut "Cmd-Enter" on a Mac or "Ctrl-Enter" on a Windows machine to execute a query.) The results are displayed in the box below your query.
+Let’s write an SQL query that selects all of the columns in the surveys table. SQL queries can be written in the box located under the "Execute SQL" tab. Click on the right arrow above the query box to execute the query. (You can also use the keyboard shortcut "Cmd-Enter" on a Mac or "Ctrl-Enter" on a Windows machine to execute a query.) The results are displayed in the box below your query. If you want to display all of the columns in a table, use the wildcard *.
 
-    SELECT year
+    SELECT *
     FROM surveys;
 
 We have capitalized the words SELECT and FROM because they are SQL keywords.
 SQL is case insensitive, but it helps for readability, and is good style.
+
+If we want to select a single column, we can type the column name instead of the wildcard *.
+
+    SELECT year
+    FROM surveys;
 
 If we want more information, we can just add a new column to the list of fields,
 right after SELECT:
@@ -37,16 +40,11 @@ right after SELECT:
     SELECT year, month, day
     FROM surveys;
 
-Or we can select all of the columns in a table using the wildcard *
-
-    SELECT *
-    FROM surveys;
-
 ### Limiting results
 
 Sometimes you don't want to see all the results you just want to get a sense of
 of what's being returned. In that case you can use the LIMIT command. In particular
-you would want to do this if you were working with large databases.
+you would want to do this if you were working with large databases. 
 
     SELECT *
     FROM surveys


### PR DESCRIPTION
Following the examples in the rest of the lesson that proceed by limiting data rather than selecting more data, I think the first example should be the wildcard rather than "year".