### PR TITLE
Numerous corrections to the Import subsection of 00-sql-introduction.md

### DIFF
--- a/_episodes/00-sql-introduction.md
+++ b/_episodes/00-sql-introduction.md
@@ -181,18 +181,19 @@ database.  We'll be creating this database from the three `csv` files
 we downloaded earlier.  Close the currently open database (**File > Close Database**) and then 
 follow these instructions: 
 
-1. Start a New Database 
-    - Click on the **New Database** icon or select **File >> New Database**
+1. Start a new database:
+    - Click on the **New Database** icon or select **File >> New Database...**
     - Assign a name to the new database, choose the folder where you'd like to save it, and click **Save**. This creates the database in the selected folder.
-2. Choose Start the import **Database -> Import**
-3. We will be importing tables and not creating tables from scratch, so click **Cancel** to edit out of the next pop-up window.
-4. Select **File > Import > Table from CSV file...** Choose surveys.csv from the data folder we downloaded and click **Open**.
+2. Click **Cancel** to close the next pop-up window (titled **Edit table definition**), since we will be importing tables and not creating tables from scratch.
+3. Select **File >> Import >> Table from CSV file...**
+4. Choose `surveys.csv` from the data folder we downloaded and click **Open**.
 5. Give the table a name that matches the file name or use the default.
-6. If the first row has column headings, be sure to check the box next to "Column names in first line."
-7. Be sure the field separator and quotation options are correct. If you're not sure which options are correct, test some of the options and until the preview at the bottom of the window looks right. 
-8. Click **OK**
-9. Back on the Database Structure tab, you should now see the table listed. Right click on the table name and choose **Modify Table**, or click on the **Modify Table** just under the tabs and above the table.
-10. In the center panel of the windown you'll see, set the data types for each field using the suggestions in the table below (this includes fields from `plots` and `species` tables also):
+6. If the first row has column headings, be sure to check the box next to "Column names in first line".
+7. Be sure the field separator and quotation options are correct. If you're not sure which options are correct, test some of the options until the preview at the bottom of the window looks right.
+8. Click **OK**.
+9. Back on the Database Structure tab, you should now see the table listed. Right click on the table name and choose **Modify Table**, or click on the **Modify Table** button just under the tabs and above the table list.
+10. Click **Save** if asked to save all pending changes.
+11. In the center panel of the window that appears, set the data types for each field using the suggestions in the table below (this includes fields from the `plots` and `species` tables also):
 
 | Field             | Data Type      | Motivation                                                                       | Table(s)          |
 |-------------------|:---------------|----------------------------------------------------------------------------------|-------------------|
@@ -211,7 +212,7 @@ follow these instructions:
 | year              | INTEGER        | Allows for meaningful arithmetic and comparisons                                 | surveys           |
 
 
-Finally, click **OK** one more time to confirm the operation.
+12. Finally, click **OK** one more time to confirm the operation.
 
 
 > ## Challenge


### PR DESCRIPTION
Hi, I've made some modifications to the Import instructions list as part of the lesson "Databases using SQL". The only modifcations were in 00-sql-introduction.md.

These changes make the instructions clearer and correct numerous typos and various inconsistencies, to better reflect a learner following the steps.

An overview of the specific changes:
(Step numbered refers to the pre-modifed version):
	- Menu selection steps had a mix of separators:  `>>`, `->`, `>`. Changed to just be `>>`.
	- Removed the line `Choose Start the import **Database -> Import**`
	- Changed the list numbering as appropriate (although we could use lazy list numbering and  Markdown will correctly order for us).
	- Split line 4 into two instructions
	- For step 7: “test some of the options and until the preview”: removed the word “and”
	- Step 10: ‘windown’ corrected to ‘window’
	- The last instruction beginning “Finally,” gets numbered in the steps of instructions.
	- Numerous other small typographic changes for consistency.
Cheers.
