### PR TITLE
add 'select' to list of SQL query types (fixes #301)

### DIFF
--- a/_episodes/00-sql-introduction.md
+++ b/_episodes/00-sql-introduction.md
@@ -37,7 +37,7 @@ use it for analysis and visualization.
 ## What is SQL?
 
 SQL stands for Structured Query Language. SQL allows us to interact with relational databases through queries. 
-These queries can allow you to perform a number of actions such as: insert, update and delete information in a database.
+These queries can allow you to perform a number of actions such as: insert, select, update and delete information in a database.
 
 
 ## Dataset Description


### PR DESCRIPTION
This edit to the "What is SQL?" section of episode 00 adds "select" to the types of database operations afforded by SQL, per @SebastianMosidi 's suggestion.