### PR TITLE
Update setup.md

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -33,7 +33,7 @@ title: Setup
 
 > ## Am I ready? 
 > 
-> The [first lesson episode](/00-sql-introduction/index.html) has instructions
+> The [first lesson episode](/sql-ecology-lesson/00-sql-introduction/index.html) has instructions
 > on loading the data in DB Browser. If you can follow the instructions under "Relational
 > Databases" or "Import", everything should have downloaded and installed correctly. 
 > 


### PR DESCRIPTION
Line 36 > The [first lesson episode](/00-sql-introduction/index.html) has instructions is a broken link.

My proposed change is:

Line 36 >  The [first lesson episode](/sql-ecology-lesson/00-sql-introduction/index.html)

or 

Line 36 > The [first lesson episode](https://datacarpentry.org/sql-ecology-lesson/00-sql-introduction/index.html) 


depending on directory format. Hope this helps! --Ryan

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
