### PR TITLE
simplified data type table

### DIFF
--- a/episodes/00-sql-introduction.md
+++ b/episodes/00-sql-introduction.md
@@ -235,46 +235,16 @@ You can also use this same approach to append new fields to an existing table.
 
 ### Data types {#datatypes}
 
+SQLite has four data types, shown in the table below.
+
 | Data type                                             | Description                                                                                              | 
 | ----------------------------------------------------- | :------------------------------------------------------------------------------------------------------- |
-| CHARACTER(n)                                          | Character string. Fixed-length n                                                                         | 
-| VARCHAR(n) or CHARACTER VARYING(n)                    | Character string. Variable length. Maximum length n                                                      | 
-| BINARY(n)                                             | Binary string. Fixed-length n                                                                            | 
-| BOOLEAN                                               | Stores TRUE or FALSE values                                                                              | 
-| VARBINARY(n) or BINARY VARYING(n)                     | Binary string. Variable length. Maximum length n                                                         | 
-| INTEGER(p)                                            | Integer numerical (no decimal).                                                                          | 
-| SMALLINT                                              | Integer numerical (no decimal).                                                                          | 
-| INTEGER                                               | Integer numerical (no decimal).                                                                          | 
-| BIGINT                                                | Integer numerical (no decimal).                                                                          | 
-| DECIMAL(p,s)                                          | Exact numerical, precision p, scale s.                                                                   | 
-| NUMERIC(p,s)                                          | Exact numerical, precision p, scale s. (Same as DECIMAL)                                                 | 
-| FLOAT(p)                                              | Approximate numerical, mantissa precision p. A floating number in base 10 exponential notation.          | 
+| TEXT                                                  | Character string                                                                                         | 
+| BLOB                                                  | Raw binary data                                                                                          | 
+| INTEGER                                               | Integer numerical (signed positive or negative)                                                          | 
 | REAL                                                  | Approximate numerical                                                                                    | 
-| FLOAT                                                 | Approximate numerical                                                                                    | 
-| DOUBLE PRECISION                                      | Approximate numerical                                                                                    | 
-| DATE                                                  | Stores year, month, and day values                                                                       | 
-| TIME                                                  | Stores hour, minute, and second values                                                                   | 
-| TIMESTAMP                                             | Stores year, month, day, hour, minute, and second values                                                 | 
-| INTERVAL                                              | Composed of a number of integer fields, representing a period of time, depending on the type of interval | 
-| ARRAY                                                 | A set-length and ordered collection of elements                                                          | 
-| MULTISET                                              | A variable-length and unordered collection of elements                                                   | 
-| XML                                                   | Stores XML data                                                                                          | 
 
-### SQL Data Type Quick Reference {#datatypediffs}
-
-Different databases offer different choices for the data type definition.
-
-The following table shows some of the common names of data types between the various database platforms:
-
-| Data type                                             | Access                                                                                                   | SQLServer                                                               | Oracle           | MySQL         | PostgreSQL    | 
-| :---------------------------------------------------- | :------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------- | :--------------- | :------------ | :------------ |
-| boolean                                               | Yes/No                                                                                                   | Bit                                                                     | Byte             | N/A           | Boolean       | 
-| integer                                               | Number (integer)                                                                                         | Int                                                                     | Number           | Int / Integer | Int / Integer | 
-| float                                                 | Number (single)                                                                                          | Float / Real                                                            | Number           | Float         | Numeric       | 
-| currency                                              | Currency                                                                                                 | Money                                                                   | N/A              | N/A           | Money         | 
-| string (fixed)                                        | N/A                                                                                                      | Char                                                                    | Char             | Char          | Char          | 
-| string (variable)                                     | Text (\<256) / Memo (65k+)                                                                                | Varchar                                                                 | Varchar2         | Varchar       | Varchar       | 
-| binary object	OLE Object Memo	Binary (fixed up to 8K) | Varbinary (\<8K)                                                                                          | Image (\<2GB)	Long                                                       | Raw	Blob         | Text	Binary   | Varbinary     | 
+In addition to these four data types, SQLite has a NULL value for missing data. We will talk more about dealing with missing data in Episode 3.
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 


### PR DESCRIPTION
_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._
Closes #316 

_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._
Simplified the changes to the descriptions of the data types in SQLite, since SQLite & the DB Browser for SQLite only use these data types anyway. Though, I don't believe the discussion in #316 was quite correct about exactly what the data types are, and went by the documentation for SQLite: https://www.sqlite.org/datatype3.html

_If any relevant discussions have taken place elsewhere, please provide links to these._


<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
